### PR TITLE
chore: add missing dependencies in requirements.txt

### DIFF
--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -10,3 +10,7 @@ pyyaml>=6.0.1
 tqdm
 datasets
 huggingface_hub
+torch
+torchvision
+matplotlib
+seaborn


### PR DESCRIPTION
The current `requirements_minimal.txt` is missing some dependencies:
- [ ] torch
- [ ] torchvision
- [ ] matplotlib
- [ ] seaborn

This PR update the `requirements_minimal.txt` to fix this issue.