### PR TITLE
feat: improve data path management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,219 @@
+# Training Artifacts
+results/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ You can prepare the data using scripts from our previous works:
 Or download the **preprocessed datasets** directly from Hugging Face:
 [https://huggingface.co/datasets/eth-siplab/Learning-with-FrameProjections](https://huggingface.co/datasets/eth-siplab/Learning-with-FrameProjections)
 
+**Data location:** By default, datasets are expected in `/data/`. To use a custom location, set the `DATA_ROOT` environment variable:
+
+```bash
+export DATA_ROOT=/path/to/your/datasets
+python main.py --dataset hhar
+```
+
+Expected directory structure under `$DATA_ROOT`:
+```
+$DATA_ROOT/
+├── HHAR/
+│   └── Activity recognition exp/
+├── IEEE_Small/
+├── IEEE_Big/
+├── UCI HAR Dataset/
+├── ECG_data/
+├── DaLia/
+├── usc_data/
+├── sleep_combined.pt
+└── clemson.mat
+```
+
 ---
 
 ### Environment

--- a/data_preprocess/data_preprocess_IEEE_big.py
+++ b/data_preprocess/data_preprocess_IEEE_big.py
@@ -7,11 +7,12 @@ import scipy.io
 import pickle as cp
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
 from data_preprocess.augmentations import gen_aug
+from data_preprocess.data_preprocess_utils import get_dataset_path
 from utils import WaveletTransform, FourierTransform
 
 
 def load_domain_data(domain_idx):
-    str_folder = '/data/IEEE_Big/'
+    str_folder = get_dataset_path('IEEE_Big') + '/'
     data_all = scipy.io.loadmat(str_folder + 'IEEE_Big.mat') 
     data = data_all['whole_dataset']
     domain_idx = int(domain_idx)

--- a/data_preprocess/data_preprocess_IEEE_small.py
+++ b/data_preprocess/data_preprocess_IEEE_small.py
@@ -7,11 +7,12 @@ import scipy.io
 import pickle as cp
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
 from data_preprocess.augmentations import gen_aug
+from data_preprocess.data_preprocess_utils import get_dataset_path
 from utils import WaveletTransform, FourierTransform
 
 
 def load_domain_data(domain_idx):
-    str_folder = '/data/IEEE_Small/'
+    str_folder = get_dataset_path('IEEE_Small') + '/'
     data_all = scipy.io.loadmat(str_folder + 'IEEE_Small.mat') 
     data = data_all['whole_dataset']
     domain_idx = int(domain_idx)

--- a/data_preprocess/data_preprocess_clemson.py
+++ b/data_preprocess/data_preprocess_clemson.py
@@ -7,10 +7,11 @@ import random
 import scipy.io
 import pickle as cp
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
+from data_preprocess.data_preprocess_utils import get_data_root
 from utils import WaveletTransform, FourierTransform
 
 def load_domain_data(domain_idx):
-    str_folder = '/data/'
+    str_folder = get_data_root() + '/'
     data_all = scipy.io.loadmat(str_folder + 'clemson.mat')
     data_all = data_all['whole_data']
     domain_idx = int(domain_idx)

--- a/data_preprocess/data_preprocess_dalia.py
+++ b/data_preprocess/data_preprocess_dalia.py
@@ -11,11 +11,12 @@ import torch
 import scipy.io
 import pickle as cp
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
+from data_preprocess.data_preprocess_utils import get_dataset_path
 from utils import WaveletTransform, FourierTransform
 
 
 def load_domain_data(domain_idx):
-    str_folder = '/data/DaLia/'
+    str_folder = get_dataset_path('DaLia') + '/'
     file = open(str_folder + 'Dalia_data.pkl', 'rb')
     data = cp.load(file)
     data = data['whole_dataset']

--- a/data_preprocess/data_preprocess_ecg.py
+++ b/data_preprocess/data_preprocess_ecg.py
@@ -10,13 +10,13 @@ from torchvision import transforms
 import torch
 import scipy.io
 import pickle as cp
-from data_preprocess.data_preprocess_utils import get_sample_weights, train_test_val_split
+from data_preprocess.data_preprocess_utils import get_sample_weights, train_test_val_split, get_dataset_path
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
 from utils import WaveletTransform, FourierTransform
 
 
 def load_domain_data(domain_idx):
-    str_folder = '/data/ECG_data/'
+    str_folder = get_dataset_path('ECG_data') + '/'
     file = open(str_folder + 'ECG_data.pkl', 'rb')
     data = cp.load(file)
     data = data['whole_dataset']

--- a/data_preprocess/data_preprocess_hhar.py
+++ b/data_preprocess/data_preprocess_hhar.py
@@ -11,7 +11,7 @@ from scipy.interpolate import interp1d
 import torch
 import pickle5 as cp
 from torch.utils.data import Dataset, DataLoader
-from data_preprocess.data_preprocess_utils import get_sample_weights, opp_sliding_window, normalize, train_test_val_split
+from data_preprocess.data_preprocess_utils import get_sample_weights, opp_sliding_window, normalize, train_test_val_split, get_dataset_path
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
 from utils import WaveletTransform, FourierTransform
 
@@ -61,10 +61,10 @@ def sep_user_device_gt():
     gt_list = ['bike', 'sit', 'stand', 'walk', 'stairsup', 'stairsdown', 'null']
     watch_device = ['gear_1', 'gear_2', 'lgwatch_1', 'lgwatch_2']
     phone_device = ['nexus4_1', 'nexus4_2', 's3_1', 's3_2', 's3mini_1', 's3mini_2', 'samsungold_1', 'samsungold_2']
-    dataDir = '/data/HHAR/Activity recognition exp/'
+    dataDir = get_dataset_path('HHAR/Activity recognition exp/')
     fileInList = os.listdir(dataDir)
 
-    saveDir = '/data/HHAR/avtivity_data_separated/'
+    saveDir = get_dataset_path('HHAR/avtivity_data_separated/')
     if not os.path.exists(saveDir):
         os.mkdir(saveDir)
         
@@ -88,8 +88,8 @@ def sep_user_device_gt():
                     sep_df.to_csv(saveDir+cur_file_name)
 
 def combine_acc_gyr():
-    dataDir = '/data/HHAR/avtivity_data_separated/'
-    saveDir = '/data/HHAR/avtivity_data_acc_gyr/'
+    dataDir = get_dataset_path('HHAR/avtivity_data_separated/')
+    saveDir = get_dataset_path('HHAR/avtivity_data_acc_gyr/')
     if not os.path.exists(saveDir):
         os.mkdir(saveDir)
     user_list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
@@ -140,8 +140,8 @@ def combine_acc_gyr():
                 df_acc_gyr.to_csv(saveDir+cur_file_name)
 
 def interpolate():
-    dataDir = '/data/HHAR/avtivity_data_acc_gyr/'
-    saveDir = '/data/HHAR/avtivity_data_acc_gyr_interp/'
+    dataDir = get_dataset_path('HHAR/avtivity_data_acc_gyr/')
+    saveDir = get_dataset_path('HHAR/avtivity_data_acc_gyr_interp/')
     if not os.path.exists(saveDir):
         os.mkdir(saveDir)
     user_list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
@@ -216,7 +216,7 @@ def preprocess():
 
 def split_train_test_subject(train_user, test_user, device, SLIDING_WINDOW_LEN=100, SLIDING_WINDOW_STEP=50):
     # todo besides user domain, consider device domain
-    dataDir = '/data/HHAR/avtivity_data_acc_gyr_interp/'
+    dataDir = get_dataset_path('HHAR/avtivity_data_acc_gyr_interp/')
     if os.path.isdir(dataDir) == False:
         preprocess()
     user_list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
@@ -278,7 +278,7 @@ def split_train_test_subject(train_user, test_user, device, SLIDING_WINDOW_LEN=1
 
 def split_train_test_subject_sp(train_user, test_user, device, SLIDING_WINDOW_LEN=100, SLIDING_WINDOW_STEP=50):
     # todo besides user domain, consider device domain
-    dataDir = '/data/HHAR/avtivity_data_acc_gyr_interp/'
+    dataDir = get_dataset_path('HHAR/avtivity_data_acc_gyr_interp/')
     if os.path.isdir(dataDir) == False:
         preprocess()
     user_list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
@@ -354,8 +354,8 @@ def split_train_test_subject_sp(train_user, test_user, device, SLIDING_WINDOW_LE
 
 def split_train_test(device, args, SLIDING_WINDOW_LEN=100, SLIDING_WINDOW_STEP=50):
     # device: 'Watch' or 'Phones'
-    dataDir = '/data/HHAR/avtivity_data_acc_gyr_interp/'
-    preprocess_Dir = '/data/HHAR/hhar_processed_'+device+'.data'
+    dataDir = get_dataset_path('HHAR/avtivity_data_acc_gyr_interp/')
+    preprocess_Dir = get_dataset_path('HHAR/hhar_processed_'+device+'.data')
     if os.path.isfile(preprocess_Dir) == True:
         #print('data is preprocessed in advance! Loading...')
         data = np.load(preprocess_Dir, allow_pickle=True)

--- a/data_preprocess/data_preprocess_sleep.py
+++ b/data_preprocess/data_preprocess_sleep.py
@@ -11,10 +11,11 @@ import torch
 import scipy.io
 import pickle as cp
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
+from data_preprocess.data_preprocess_utils import get_data_root
 from utils import WaveletTransform, FourierTransform
 
 def load_domain_data():
-    str_folder = '/data/'
+    str_folder = get_data_root() + '/'
     data = torch.load(str_folder + 'sleep_combined.pt')
     train = data['train']
     val = data['val']

--- a/data_preprocess/data_preprocess_ucihar.py
+++ b/data_preprocess/data_preprocess_ucihar.py
@@ -9,7 +9,7 @@ from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms
 import torch
 import pickle as cp
-from data_preprocess.data_preprocess_utils import get_sample_weights, train_test_val_split, train_val_split
+from data_preprocess.data_preprocess_utils import get_sample_weights, train_test_val_split, train_val_split, get_dataset_path
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
 from utils import WaveletTransform, FourierTransform
 
@@ -41,7 +41,7 @@ def load_domain_data(domain_idx):
     :param domain_idx: index of a single domain
     :return: X and y data of the entire domain
     """
-    data_dir = '/data/ucihar/'
+    data_dir = get_dataset_path('ucihar/')
     saved_filename = 'ucihar_domain_' + domain_idx + '_wd.data' # "wd": with domain label
 
     if os.path.isfile(data_dir + saved_filename) == True:
@@ -52,7 +52,7 @@ def load_domain_data(domain_idx):
     else:
         if os.path.isdir(data_dir) == False:
             os.makedirs(data_dir)
-        str_folder = './data/UCI HAR Dataset/'
+        str_folder = get_dataset_path('UCI HAR Dataset/')
         INPUT_SIGNAL_TYPES = [
             "body_acc_x_",
             "body_acc_y_",

--- a/data_preprocess/data_preprocess_usc.py
+++ b/data_preprocess/data_preprocess_usc.py
@@ -10,13 +10,13 @@ from torchvision import transforms
 import torch
 import scipy.io
 import pickle as cp
-from data_preprocess.data_preprocess_utils import get_sample_weights, train_test_val_split
+from data_preprocess.data_preprocess_utils import get_sample_weights, train_test_val_split, get_dataset_path
 from data_preprocess.base_loader import base_loader, base_loader_isoalign
 from utils import WaveletTransform, FourierTransform
 
 
 def load_domain_data(domain_idx):
-    str_folder = '/data/usc_data/'
+    str_folder = get_dataset_path('usc_data') + '/'
     data_all = scipy.io.loadmat(str_folder + 'usc_data.mat')
     data = data_all['whole_dataset']
     domain_idx = int(domain_idx)

--- a/data_preprocess/data_preprocess_utils.py
+++ b/data_preprocess/data_preprocess_utils.py
@@ -1,7 +1,20 @@
+import os
 import numpy as np
 from numpy.lib.stride_tricks import as_strided as ast
 # from dataclasses import dataclass
 from sklearn.model_selection import train_test_split
+
+# Environment variable for data root directory
+DATA_ROOT_ENV_VAR = "DATA_ROOT"
+DEFAULT_DATA_ROOT = "/data"
+
+def get_data_root():
+    """Returns DATA_ROOT env var or '/data' by default."""
+    return os.environ.get(DATA_ROOT_ENV_VAR, DEFAULT_DATA_ROOT)
+
+def get_dataset_path(subpath):
+    """Join data root with dataset subpath."""
+    return os.path.join(get_data_root(), subpath)
 
 # @dataclass
 # class Params:

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -10,3 +10,7 @@ pyyaml>=6.0.1
 tqdm
 datasets
 huggingface_hub
+torch
+torchvision
+matplotlib
+seaborn


### PR DESCRIPTION
In the current data preprocess scripts, the data path is hardcoded at `/data/...`. Which might not be convinient when using a different setup. In this PR, we:
- Remove the path duplication and write it in `data_preprocess_utils.py`
- Use `os.environ.get` with the default behavior in `/data/` to allow the users to customize the data path easily
- Document the feature and the expected data directory structure